### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blu-hawaii.yml
+++ b/.github/workflows/blu-hawaii.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: blu-hawaii CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jliuhtonen/blu-hawaii/security/code-scanning/2](https://github.com/jliuhtonen/blu-hawaii/security/code-scanning/2)

To fix the issue, add a top-level `permissions` block to the workflow YAML file, `.github/workflows/blu-hawaii.yml`, specifying the least privilege required (`contents: read`). This restricts the GITHUB_TOKEN for all jobs in this workflow to only read repository contents (files), which is sufficient for running builds, tests, and checkout steps, and mitigates the risk of unauthorized or accidental repository modifications. The change must be made at the root level of the workflow file (just below the `name:` or above/below the `on:` block). No imports, additional definitions, or method changes are required for this fix—just a single line/block added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
