### PR TITLE
Replace xml-js with fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@jliuhtonen/nightvision": "^0.2.4",
+        "fast-xml-parser": "^5.8.0",
         "ky": "^2.0.0",
         "pino": "^10.2.1",
         "rxjs": "^7.8.2",
-        "xml-js": "^1.6.11",
         "zod": "^4.3.5"
       },
       "bin": {
@@ -50,6 +50,18 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
@@ -141,6 +153,44 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/help-me": {
       "version": "5.0.0",
@@ -235,6 +285,21 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/pino": {
       "version": "10.3.1",
@@ -384,12 +449,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
     "node_modules/secure-json-parse": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
@@ -445,6 +504,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -491,16 +562,19 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
-      "dependencies": {
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "xml-js": "bin/cli.js"
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "dependencies": {
     "@jliuhtonen/nightvision": "^0.2.4",
+    "fast-xml-parser": "^5.8.0",
     "ky": "^2.0.0",
     "pino": "^10.2.1",
     "rxjs": "^7.8.2",
-    "xml-js": "^1.6.11",
     "zod": "^4.3.5"
   }
 }

--- a/src/bluOs/player.ts
+++ b/src/bluOs/player.ts
@@ -50,9 +50,7 @@ const bluOsStatus = zod
     title2: value.status.title2,
     title3: value.status.title3,
     secs: Number(value.status.secs),
-    totalLength: value.status.totlen
-      ? Number(value.status.totlen)
-      : undefined,
+    totalLength: value.status.totlen ? Number(value.status.totlen) : undefined,
     state: value.status.state,
     groupName: value.status.groupName,
   }))

--- a/src/bluOs/player.ts
+++ b/src/bluOs/player.ts
@@ -13,52 +13,48 @@ import {
   tap,
   timer,
 } from "rxjs"
-import { xml2js } from "xml-js"
+import { XMLParser } from "fast-xml-parser"
 import * as zod from "zod"
 import type { Logger } from "pino"
 import { createEtagCache } from "./etagCache.ts"
 import type { Player } from "./serviceDiscovery.ts"
 
-const xmlTextField = zod.object({
-  _text: zod.string(),
-})
-
-const xmlJsEtag = zod
+const bluOsEtag = zod
   .object({
     status: zod.object({
-      _attributes: zod.object({
-        etag: zod.string(),
-      }),
+      "@_etag": zod.string(),
     }),
   })
-  .transform((s) => s.status._attributes.etag)
+  .transform((s) => s.status["@_etag"])
 
-const xmlJsStatus = zod
+const bluOsStatus = zod
   .object({
     status: zod.object({
-      artist: xmlTextField,
-      album: xmlTextField,
-      name: xmlTextField.optional(),
-      title1: xmlTextField,
-      title2: xmlTextField,
-      title3: xmlTextField.optional(),
-      secs: xmlTextField,
-      totlen: xmlTextField.optional(),
-      state: xmlTextField,
-      groupName: xmlTextField.optional(),
+      artist: zod.string(),
+      album: zod.string(),
+      name: zod.string().optional(),
+      title1: zod.string(),
+      title2: zod.string(),
+      title3: zod.string().optional(),
+      secs: zod.string(),
+      totlen: zod.string().optional(),
+      state: zod.string(),
+      groupName: zod.string().optional(),
     }),
   })
   .transform((value) => ({
-    artist: value.status.artist._text,
-    album: value.status.album._text,
-    name: value.status.name?._text,
-    title1: value.status.title1._text,
-    title2: value.status.title2._text,
-    title3: value.status.title3?._text,
-    secs: Number(value.status.secs._text),
-    totalLength: value.status.totlen && Number(value.status.totlen._text),
-    state: value.status.state._text,
-    groupName: value.status.groupName?._text,
+    artist: value.status.artist,
+    album: value.status.album,
+    name: value.status.name,
+    title1: value.status.title1,
+    title2: value.status.title2,
+    title3: value.status.title3,
+    secs: Number(value.status.secs),
+    totalLength: value.status.totlen
+      ? Number(value.status.totlen)
+      : undefined,
+    state: value.status.state,
+    groupName: value.status.groupName,
   }))
 
 export interface BluOsConfig {
@@ -72,7 +68,7 @@ export interface StatusQueryResponse {
   playingTrack?: PlayingTrack
 }
 
-export type PlayingBluOsTrack = zod.infer<typeof xmlJsStatus>
+export type PlayingBluOsTrack = zod.infer<typeof bluOsStatus>
 
 export type PlayingTrack = {
   artist: string
@@ -137,11 +133,16 @@ const resolveTrackName = (t: PlayingBluOsTrack): string =>
     ? t.title1
     : t.title2)
 
-const parseBluOsStatus = (bluOsXml: string): StatusQueryResponse => {
-  const parsedJs = xml2js(bluOsXml, { compact: true })
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  parseTagValue: false,
+})
 
-  const etag = xmlJsEtag.parse(parsedJs)
-  const parsedData = xmlJsStatus.safeParse(parsedJs)
+const parseBluOsStatus = (bluOsXml: string): StatusQueryResponse => {
+  const parsedJs = xmlParser.parse(bluOsXml)
+
+  const etag = bluOsEtag.parse(parsedJs)
+  const parsedData = bluOsStatus.safeParse(parsedJs)
 
   if (parsedData.success) {
     const { artist, album, secs, totalLength, state, groupName } =

--- a/test/bluosPlayer.test.ts
+++ b/test/bluosPlayer.test.ts
@@ -5,7 +5,10 @@ import { trackStreamingResponse } from "./util/bluOsUtil.ts"
 import { createPlayersStatusObservable } from "../src/bluOs/player.ts"
 import pino from "pino"
 import { of } from "rxjs"
-import { assertNumberOfObservableResults } from "./util/rxUtil.ts"
+import {
+  assertNumberOfObservableResults,
+  assertObservableResults,
+} from "./util/rxUtil.ts"
 
 const generatePlayers = (count: number): Player[] => {
   const players: Player[] = []
@@ -89,5 +92,44 @@ describe("BluOS player status", () => {
       // Node 25 CI can have more scheduling jitter; leave some headroom.
       15000,
     )
+  })
+
+  it("should keep numeric-only metadata as strings", async () => {
+    const player: Player = { ip: "192.168.1.50", port: 11000 }
+    const numericTrack = {
+      artist: "311",
+      album: "21",
+      title: "1989",
+      secs: 5,
+      totalLength: 100,
+      state: "stream",
+      etag: "numEtag",
+    }
+    nock(`http://${player.ip}:${player.port}`)
+      .get("/Status")
+      .query({ timeout: "100" })
+      .reply(200, trackStreamingResponse(numericTrack))
+      .get("/Status")
+      .query({ timeout: "100", etag: "numEtag" })
+      .reply(200, trackStreamingResponse(numericTrack))
+
+    const responseObservable = createPlayersStatusObservable(
+      pino({ level: "fatal" }),
+      of([player]),
+    )
+
+    await assertObservableResults(responseObservable, [
+      {
+        etag: "numEtag",
+        playingTrack: {
+          artist: "311",
+          album: "21",
+          title: "1989",
+          secs: 5,
+          totalLength: 100,
+          state: "stream",
+        },
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- Migrates the BluOS status parser from the unmaintained `xml-js` to `fast-xml-parser` (closes #251).
- Parses with `parseTagValue: false` so numeric-only metadata stays a string (see note below).
- Adds a regression test for numeric-only metadata.

## Note on `parseTagValue: false`
fast-xml-parser parses numeric-looking text into JS numbers by default. That would turn an album titled "21" or "1989" into a number, fail the zod `string` schema, and silently drop the track from scrobbling. Disabling tag-value parsing keeps every element as a string (matching xml-js's prior behaviour); `secs`/`totlen` are converted with `Number()` in the transform, as before.

## Dependency note
fast-xml-parser v5 pulls in a few transitive deps (it bundles an XML builder we don't use). v4.x is leaner but is tagged `legacy`. I went with the current major (v5) since the issue requested this library.

## Test plan
- [x] `npm test` — 10/10 pass (incl. new numeric-metadata regression test)
- [x] `npx tsc --noEmit` — clean
- [x] `prettier src --check` — clean
- [x] Verified the new test fails without `parseTagValue: false`