### PR TITLE
Set rootDir explicitly for TypeScript 6.0 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ESNext",
     "lib": ["esnext"],
     "module": "NodeNext",
+    "rootDir": "./src",
     "rootDirs": ["./src", "./test"],
     "moduleResolution": "NodeNext",
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

- TypeScript 6.0 introduced `TS5011`, which requires `rootDir` to be set explicitly in `tsconfig.json` when `outDir` is configured, rather than inferring it from the source files.
- Adds `"rootDir": "./src"` to match the already-inferred common source directory, unblocking the Dependabot TypeScript 6.0 upgrade (#278).

## Notes

- The error only fires during emit (`npm run build`'s `tsc`), not under `--noEmit`. `rootDir: "./src"` matches the `include: ["src/**/*.ts"]` glob, which is exactly what the error message recommends.
- `rootDir` (output layout) and the existing `rootDirs` (module-resolution virtual roots) are independent settings, so there is no conflict.
- This branch is based on `main`; the actual TS 6.0 bump lives in #278. They touch different files (no conflict), but #278's CI will only go green once this lands and #278 is rebased on it.

## Test plan

- [x] Reproduced `TS5011` (exit 2) on `main` under TypeScript 6.0.3
- [x] `npx tsc` (emit mode) passes cleanly with the fix under TypeScript 6.0.3
- [x] Still compiles under the current TypeScript 5.9.3 (backwards-compatible)